### PR TITLE
Disable CSD & improve desktop entry

### DIFF
--- a/doflicky.desktop
+++ b/doflicky.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
-Name=Hardware Drivers
-GenericName=Hardware Drivers
+Name=Solus Driver Management
+GenericName=Driver Management Utility
 Comment=Install or remove hardware drivers
 Exec=/usr/bin/doflicky-ui
 Terminal=false

--- a/doflicky/window.py
+++ b/doflicky/window.py
@@ -38,13 +38,8 @@ class DoFlickyWindow(Gtk.ApplicationWindow):
         Gtk.ApplicationWindow.__init__(self)
 
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-        hbar = Gtk.HeaderBar()
-        hbar.set_show_close_button(True)
-        self.set_titlebar(hbar)
 
-        self.set_title("DoFlicky")
-        hbar.set_title("DoFlicky")
-        hbar.set_subtitle("Solus Driver Management")
+        self.set_title("Solus Driver Management")
         self.set_size_request(400, 400)
 
         self.stack = Gtk.Stack()


### PR DESCRIPTION
`GtkHeaderBar` automatically creates client side decorations. Since DoFlicky doesn't actually use CSD, and CSD looks awkward on KDE, it would be better to remove it. This also removes the "DoFlicky" title which might confuse newcomers.

![Screenshot_20200126_151714](https://user-images.githubusercontent.com/20506149/73143459-fa593b00-404e-11ea-848c-4ac4831788ae.png)

Edit: I've also edited the desktop file to make it a bit clearer what it does. Instead of "Hardware Drivers" it now says "Solus Driver Management" which clearly demonstrates that it's a tool for managing drivers on Solus.
