### PR TITLE
Add detection for Nvidia 470.xx driver packages

### DIFF
--- a/crapshoot
+++ b/crapshoot
@@ -13,6 +13,7 @@
 from doflicky import OSContext
 from doflicky.driver.nvidia import DriverBundleNvidia
 from doflicky.driver.nvidia import DriverBundleNvidia390
+from doflicky.driver.nvidia import DriverBundleNvidia470
 from doflicky.driver.broadcom import DriverBundleBroadcom
 import pisi
 from pisi.db.installdb import InstallDB
@@ -30,6 +31,7 @@ class BundleSet:
         """ Initialise the potential driver bundle set """
         self.drivers = [
             DriverBundleNvidia390(),
+            DriverBundleNvidia470(),
             DriverBundleNvidia(),
             DriverBundleBroadcom(),
         ]

--- a/doflicky/bundleset.py
+++ b/doflicky/bundleset.py
@@ -13,6 +13,7 @@
 from doflicky import OSContext
 from doflicky.driver.nvidia import DriverBundleNvidia
 from doflicky.driver.nvidia import DriverBundleNvidia390
+from doflicky.driver.nvidia import DriverBundleNvidia470
 from doflicky.driver.broadcom import DriverBundleBroadcom
 from pisi.db.installdb import InstallDB
 
@@ -30,6 +31,7 @@ class BundleSet:
         """ Initialise the potential driver bundle set """
         self.drivers = [
             DriverBundleNvidia390(),
+            DriverBundleNvidia470(),
             DriverBundleNvidia(),
             DriverBundleBroadcom(),
         ]

--- a/doflicky/detection.py
+++ b/doflicky/detection.py
@@ -67,6 +67,7 @@ class DriverBundlePCI(DriverBundle):
 
 
 nvidia_driver_priority = ['nvidia-glx-driver',
+                          'nvidia-470-glx-driver',
                           'nvidia-390-glx-driver']
 
 

--- a/doflicky/driver/nvidia.py
+++ b/doflicky/driver/nvidia.py
@@ -56,6 +56,29 @@ class DriverBundleNvidia(DriverBundleNvidiaBase):
             basePackages.append("nvidia-glx-driver")
         return basePackages
 
+class DriverBundleNvidia470(DriverBundleNvidiaBase):
+    """ NVIDIA driver 470 (nvidia-470-glx-driver) """
+
+    def __init__(self):
+        DriverBundleNvidiaBase.__init__(self,
+                                        "nvidia-470-glx-driver.modaliases")
+
+    def get_name(self):
+        return "NVIDIA Graphics Driver (470.xx series)"
+
+    def get_priority(self):
+        return 2
+
+    def get_packages(self, context, emul32=False):
+        basePackages = ["nvidia-470-glx-driver-common"]
+        if emul32:
+            basePackages.append("nvidia-470-glx-driver-32bit")
+        if context.get_active_kernel_series() == "current":
+            basePackages.append("nvidia-470-glx-driver-current")
+        else:
+            basePackages.append("nvidia-470-glx-driver")
+        return basePackages
+
 class DriverBundleNvidia390(DriverBundleNvidiaBase):
     """ NVIDIA driver 390 (nvidia-390-glx-driver) """
 
@@ -67,7 +90,7 @@ class DriverBundleNvidia390(DriverBundleNvidiaBase):
         return "NVIDIA Graphics Driver (390.xx series)"
 
     def get_priority(self):
-        return 2
+        return 1
 
     def get_packages(self, context, emul32=False):
         basePackages = ["nvidia-390-glx-driver-common"]


### PR DESCRIPTION
This adds detection for the newly added Nvidia 470.xx driver packages (to support Kepler GPUs).

After the next sync these packages will be in the Stable repository, and then I will switch the main branch to the 510.xx series (and post PSAs to inform users of older cards they'll have to switch to this new driver package set).