### PR TITLE
Remove Nvidia 390.xx driver series

### DIFF
--- a/crapshoot
+++ b/crapshoot
@@ -12,7 +12,6 @@
 
 from doflicky import OSContext
 from doflicky.driver.nvidia import DriverBundleNvidia
-from doflicky.driver.nvidia import DriverBundleNvidia390
 from doflicky.driver.nvidia import DriverBundleNvidia470
 from doflicky.driver.broadcom import DriverBundleBroadcom
 import pisi
@@ -30,7 +29,6 @@ class BundleSet:
     def __init__(self):
         """ Initialise the potential driver bundle set """
         self.drivers = [
-            DriverBundleNvidia390(),
             DriverBundleNvidia470(),
             DriverBundleNvidia(),
             DriverBundleBroadcom(),

--- a/doflicky/bundleset.py
+++ b/doflicky/bundleset.py
@@ -12,7 +12,6 @@
 
 from doflicky import OSContext
 from doflicky.driver.nvidia import DriverBundleNvidia
-from doflicky.driver.nvidia import DriverBundleNvidia390
 from doflicky.driver.nvidia import DriverBundleNvidia470
 from doflicky.driver.broadcom import DriverBundleBroadcom
 from pisi.db.installdb import InstallDB
@@ -30,7 +29,6 @@ class BundleSet:
     def __init__(self):
         """ Initialise the potential driver bundle set """
         self.drivers = [
-            DriverBundleNvidia390(),
             DriverBundleNvidia470(),
             DriverBundleNvidia(),
             DriverBundleBroadcom(),

--- a/doflicky/detection.py
+++ b/doflicky/detection.py
@@ -67,8 +67,7 @@ class DriverBundlePCI(DriverBundle):
 
 
 nvidia_driver_priority = ['nvidia-glx-driver',
-                          'nvidia-470-glx-driver',
-                          'nvidia-390-glx-driver']
+                          'nvidia-470-glx-driver']
 
 
 def detect_hardware_packages():

--- a/doflicky/driver/nvidia.py
+++ b/doflicky/driver/nvidia.py
@@ -78,26 +78,3 @@ class DriverBundleNvidia470(DriverBundleNvidiaBase):
         else:
             basePackages.append("nvidia-470-glx-driver")
         return basePackages
-
-class DriverBundleNvidia390(DriverBundleNvidiaBase):
-    """ NVIDIA driver 390 (nvidia-390-glx-driver) """
-
-    def __init__(self):
-        DriverBundleNvidiaBase.__init__(self,
-                                        "nvidia-390-glx-driver.modaliases")
-
-    def get_name(self):
-        return "NVIDIA Graphics Driver (390.xx series)"
-
-    def get_priority(self):
-        return 1
-
-    def get_packages(self, context, emul32=False):
-        basePackages = ["nvidia-390-glx-driver-common"]
-        if emul32:
-            basePackages.append("nvidia-390-glx-driver-32bit")
-        if context.get_active_kernel_series() == "current":
-            basePackages.append("nvidia-390-glx-driver-current")
-        else:
-            basePackages.append("nvidia-390-glx-driver")
-        return basePackages


### PR DESCRIPTION
Support was dropped at the end of 2022

Corresponding solus-sc PR: https://github.com/getsolus/solus-sc/pull/200
Corresponding xorg-driver-video-nouveau diff: https://dev.getsol.us/D14141