### PR TITLE
Remove Nvidia 470.xx driver series

### DIFF
--- a/crapshoot
+++ b/crapshoot
@@ -12,7 +12,6 @@
 
 from doflicky import OSContext
 from doflicky.driver.nvidia import DriverBundleNvidia
-from doflicky.driver.nvidia import DriverBundleNvidia470
 from doflicky.driver.broadcom import DriverBundleBroadcom
 import pisi
 from pisi.db.installdb import InstallDB
@@ -29,7 +28,6 @@ class BundleSet:
     def __init__(self):
         """ Initialise the potential driver bundle set """
         self.drivers = [
-            DriverBundleNvidia470(),
             DriverBundleNvidia(),
             DriverBundleBroadcom(),
         ]

--- a/doflicky/bundleset.py
+++ b/doflicky/bundleset.py
@@ -12,7 +12,6 @@
 
 from doflicky import OSContext
 from doflicky.driver.nvidia import DriverBundleNvidia
-from doflicky.driver.nvidia import DriverBundleNvidia470
 from doflicky.driver.broadcom import DriverBundleBroadcom
 from pisi.db.installdb import InstallDB
 
@@ -29,7 +28,6 @@ class BundleSet:
     def __init__(self):
         """ Initialise the potential driver bundle set """
         self.drivers = [
-            DriverBundleNvidia470(),
             DriverBundleNvidia(),
             DriverBundleBroadcom(),
         ]

--- a/doflicky/detection.py
+++ b/doflicky/detection.py
@@ -66,8 +66,7 @@ class DriverBundlePCI(DriverBundle):
         return False
 
 
-nvidia_driver_priority = ['nvidia-glx-driver',
-                          'nvidia-470-glx-driver']
+nvidia_driver_priority = ['nvidia-glx-driver']
 
 
 def detect_hardware_packages():

--- a/doflicky/driver/nvidia.py
+++ b/doflicky/driver/nvidia.py
@@ -55,26 +55,3 @@ class DriverBundleNvidia(DriverBundleNvidiaBase):
         else:
             basePackages.append("nvidia-glx-driver")
         return basePackages
-
-class DriverBundleNvidia470(DriverBundleNvidiaBase):
-    """ NVIDIA driver 470 (nvidia-470-glx-driver) """
-
-    def __init__(self):
-        DriverBundleNvidiaBase.__init__(self,
-                                        "nvidia-470-glx-driver.modaliases")
-
-    def get_name(self):
-        return "NVIDIA Graphics Driver (470.xx series)"
-
-    def get_priority(self):
-        return 2
-
-    def get_packages(self, context, emul32=False):
-        basePackages = ["nvidia-470-glx-driver-common"]
-        if emul32:
-            basePackages.append("nvidia-470-glx-driver-32bit")
-        if context.get_active_kernel_series() == "current":
-            basePackages.append("nvidia-470-glx-driver-current")
-        else:
-            basePackages.append("nvidia-470-glx-driver")
-        return basePackages


### PR DESCRIPTION
Official support will be dropped at the end of September 2024

https://nvidia.custhelp.com/app/answers/detail/a_id/3142
https://nvidia.custhelp.com/app/answers/detail/a_id/5202

Since I was bored I already prepared this deprecation. It can be merged as soon as it becomes bothersome to maintain compatibility with the 470 driver (or earlier, if the goal is to prevent too many people to still install a driver that will be removed sooner rather than later).